### PR TITLE
chore: Save broken state of draggable tasks and expanded card behavior

### DIFF
--- a/weekwise/package-lock.json
+++ b/weekwise/package-lock.json
@@ -8,6 +8,8 @@
       "name": "weekwise",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "@supabase/supabase-js": "^2.49.4",
         "chrono-node": "^2.8.0",
         "framer-motion": "^12.10.5",
@@ -1802,6 +1804,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/weekwise/package.json
+++ b/weekwise/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@supabase/supabase-js": "^2.49.4",
     "chrono-node": "^2.8.0",
     "framer-motion": "^12.10.5",

--- a/weekwise/src/app/home/page.tsx
+++ b/weekwise/src/app/home/page.tsx
@@ -188,6 +188,30 @@ export default function HomePage() {
             }
         });
 
+    // ? DRAG-DROP TASKCARDS IN WEEKVIEW TO CHANGE DATE
+    const handleTaskDrop = async (taskId: string, newDate: string) => {
+        const user = await supabase.auth.getUser();
+        const user_id = user.data.user?.id;
+        if (!user_id) return;
+
+        const { error } = await supabase
+            .from("tasks")
+            .update({ date: newDate })
+            .eq("id", taskId)
+            .eq("user_id", user_id);
+
+        if (error) {
+            console.error("Failed to move task:", error);
+            return;
+        }
+
+        setAllTasks((prev) =>
+            prev.map((task) =>
+                task.id === taskId ? { ...task, date: newDate } : task
+            )
+        );
+    };
+
     // ? SHORTCUT: CMD + K - SEARCH BAR
     useEffect(() => {
         const handleKeyShortcut = (e: KeyboardEvent) => {
@@ -321,7 +345,7 @@ export default function HomePage() {
                         {/* // todo: expands open an input to search */}
 
                         <motion.div
-                            className="flex items-center justify-center border-1 border-gray-700 rounded-full bg-white overflow-hidden"
+                            className="flex items-center justify-center border-1 border-gray-700 rounded-full bg-white"
                             animate={{ width: isExpanded ? 280 : 38 }}
                             transition={{
                                 type: "spring",
@@ -496,6 +520,7 @@ export default function HomePage() {
                             onAddTask={handleAddTask}
                             handleCancel={() => setIsAddingTask(false)}
                             sortBy={weekSort}
+                            onTaskDrop={handleTaskDrop}
                         />
                     ) : (
                         <AllTaskView


### PR DESCRIPTION
- Implemented drag-and-drop setup for task cards in WeekView using @dnd-kit/core
- Drop zones (week day columns) are registered, but tasks fail to land—`over` is null on drag end
- Drop zone keys (ISO date strings) may be conflicting due to re-renders or duplicates
- No visual drop feedback appears (highlight on hover not working)
- As a side effect, single-click on TaskCard no longer opens expanded view

Switching back to `ui-updates` branch to focus on UI refinements while this issue is deprioritized